### PR TITLE
eslint-config-es5: treat JavaScript as ECMAScript 5

### DIFF
--- a/packages/eslint-config-es5/README.md
+++ b/packages/eslint-config-es5/README.md
@@ -1,6 +1,6 @@
 # @mitsue/eslint-config-es5
 
-[ESLint](https://eslint.org/)の基本設定ファイルです。ES5を対象にしています。
+[ESLint](https://eslint.org/)の基本設定ファイルです。ECMAScript 5を対象にしています。
 
 ## インストール
 
@@ -75,6 +75,8 @@ ESLintは未知のルールが設定されているとエラーを報告しま�
 
 ### 次期リリース
 
+- ECMAScript 5専用に変更
+    - parserOptionsのecmaVersionを5に変更
 - 対象とするESLint（peerDependencies）を^7.15.0に変更
 - 以下のenvを無効化
     - commonjs

--- a/packages/eslint-config-es5/index.js
+++ b/packages/eslint-config-es5/index.js
@@ -5,6 +5,15 @@ module.exports = {
      */
     extends: '@mitsue',
 
+    parserOptions: {
+        ecmaVersion: 5,
+    },
+    env: {
+        es6: false,
+        es2017: false,
+        es2020: false,
+    },
+
     /*
      * see also:
      * http://eslint.org/docs/rules/

--- a/packages/eslint-config-es5/test/__snapshots__/es2015.test.js.snap
+++ b/packages/eslint-config-es5/test/__snapshots__/es2015.test.js.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ECMAScript 2015 es2015_error.js 1`] = `
+Array [
+  Object {
+    "filePath": "es2015_error.js",
+    "messages": Array [
+      Object {
+        "line": 2,
+        "ruleId": "no-undef",
+        "severity": 2,
+      },
+    ],
+  },
+]
+`;
+
+exports[`ECMAScript 2015 es2015_fail.js 1`] = `
+Array [
+  Object {
+    "filePath": "es2015_fail.js",
+    "messages": Array [
+      Object {
+        "line": 1,
+        "ruleId": "Parsing error: The keyword 'const' is reserved",
+        "severity": 2,
+      },
+    ],
+  },
+]
+`;

--- a/packages/eslint-config-es5/test/es2015.test.js
+++ b/packages/eslint-config-es5/test/es2015.test.js
@@ -1,0 +1,23 @@
+/* eslint strict: [2, "global"] */
+'use strict';
+
+const path = require('path');
+const {lintFile} = require('./helper');
+
+process.chdir(__dirname);
+
+describe('ECMAScript 2015', () => {
+    test('es2015_fail.js', async () => {
+        const filePath = 'es2015_fail.js';
+        const data = await lintFile(path.join('fixtures', filePath));
+
+        expect(data).toMatchSnapshot();
+    });
+
+    test('es2015_error.js', async () => {
+        const filePath = 'es2015_error.js';
+        const data = await lintFile(path.join('fixtures', filePath));
+
+        expect(data).toMatchSnapshot();
+    });
+});

--- a/packages/eslint-config-es5/test/fixtures/.eslintrc.json
+++ b/packages/eslint-config-es5/test/fixtures/.eslintrc.json
@@ -1,13 +1,7 @@
 {
   "root": true,
   "extends": "../../index.js",
-  "parserOptions": {
-    "ecmaVersion": 5
-  },
   "env": {
     "jest": true
-  },
-  "rules": {
-    "linebreak-style": [2, "unix"]
   }
 }

--- a/packages/eslint-config-es5/test/fixtures/es2015_error.js
+++ b/packages/eslint-config-es5/test/fixtures/es2015_error.js
@@ -1,0 +1,2 @@
+/* eslint-disable no-unused-vars */
+var map = new Map(['version', 'ECMAScript 2015']);

--- a/packages/eslint-config-es5/test/fixtures/es2015_fail.js
+++ b/packages/eslint-config-es5/test/fixtures/es2015_fail.js
@@ -1,0 +1,1 @@
+const version = 'ECMAScript 2015';


### PR DESCRIPTION
Currently, eslint-config-es5 treats JavaScript as ECMAScript 2020. This causes that ESLint doesn't report any errors against JavaScript targeting legacy environments even it employs unsupported syntax and won't run.

This PR makes eslint-config-es5 treat JavaScript as ECMAScript 5 so that ESLint will report syntax errors if JavaScript is not valid ECMAScript 5.
