### PR TITLE
feat: add new ruels from ESLint 7.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@commitlint/cli": "^11.0.0",
     "@commitlint/config-conventional": "^11.0.0",
     "@types/eslint": "^7.2.4",
-    "eslint": "^7.14.0",
+    "eslint": "^7.15.0",
     "husky": "^4.3.0",
     "jest": "^26.6.3",
     "js-green-licenses": "^2.0.1",

--- a/packages/eslint-config-es5/README.md
+++ b/packages/eslint-config-es5/README.md
@@ -60,7 +60,7 @@ plugin:prettier/recommendedは必ず最後に記述してください。そう�
 
 |@mitsue/eslint-config-es5|ESLint|
 |-:|-:|
-|次期リリース|^7.14.0|
+|次期リリース|^7.15.0|
 |3.0.0|^7.4.0|
 |2.0.0|^7.4.0|
 |1.0.4|^7.1.0|
@@ -75,7 +75,7 @@ ESLintは未知のルールが設定されているとエラーを報告しま�
 
 ### 次期リリース
 
-- 対象とするESLint（peerDependencies）を^7.14.0に変更
+- 対象とするESLint（peerDependencies）を^7.15.0に変更
 - 以下のenvを無効化
     - commonjs
 - ルールに関する調整

--- a/packages/eslint-config-es5/package.json
+++ b/packages/eslint-config-es5/package.json
@@ -27,6 +27,6 @@
     "@mitsue/eslint-config": "^3.0.0"
   },
   "peerDependencies": {
-    "eslint": "^7.14.0"
+    "eslint": "^7.15.0"
   }
 }

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -60,7 +60,7 @@ plugin:prettier/recommendedは必ず最後に記述してください。そう�
 
 |@mitsue/eslint-config|ESLint|
 |-:|-:|
-|次期リリース|^7.14.0|
+|次期リリース|^7.15.0|
 |3.0.0|^7.4.0|
 |2.0.0|^7.4.0|
 |1.0.3|^7.1.0|
@@ -75,11 +75,12 @@ ESLintは未知のルールが設定されているとエラーを報告しま�
 
 ### 次期リリース
 
-- 対象とするESLint（peerDependencies）を^7.14.0に変更
+- 対象とするESLint（peerDependencies）を^7.15.0に変更
 - 以下のenvを無効化
     - commonjs
 - ルールに関する調整
     - [no-nonoctal-decimal-escape](https://eslint.org/docs/rules/no-nonoctal-decimal-escape)を2（エラー）に設定
+    - [no-unsafe-optional-chaining](https://eslint.org/docs/rules/no-unsafe-optional-chaining)を2（エラー）に設定
 
 ### 3.0.0
 

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -166,6 +166,9 @@ module.exports = {
             enforceForOrderingRelations: true,
         }],
 
+        // https://eslint.org/docs/rules/no-unsafe-optional-chaining
+        'no-unsafe-optional-chaining': 2,
+
         // https://eslint.org/docs/rules/no-useless-backreference
         'no-useless-backreference': 2,
 

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -22,6 +22,6 @@
     "access": "public"
   },
   "peerDependencies": {
-    "eslint": "^7.14.0"
+    "eslint": "^7.15.0"
   }
 }

--- a/packages/eslint-config/test/__snapshots__/eslint7.test.js.snap
+++ b/packages/eslint-config/test/__snapshots__/eslint7.test.js.snap
@@ -84,3 +84,18 @@ Array [
   },
 ]
 `;
+
+exports[`ESLint 7.15.0 7.15.0_error.js 1`] = `
+Array [
+  Object {
+    "filePath": "7.15.0_error.js",
+    "messages": Array [
+      Object {
+        "line": 3,
+        "ruleId": "no-unsafe-optional-chaining",
+        "severity": 2,
+      },
+    ],
+  },
+]
+`;

--- a/packages/eslint-config/test/eslint7.test.js
+++ b/packages/eslint-config/test/eslint7.test.js
@@ -60,3 +60,22 @@ describe('ESLint 7.14.0', () => {
         expect(data).toMatchSnapshot();
     });
 });
+
+describe('ESLint 7.15.0', () => {
+    test('7.15.0_ok.js', async () => {
+        const filePath = '7.15.0_ok.js';
+        const data = await lintFile(path.join('fixtures', 'eslint', filePath));
+
+        expect(data).toStrictEqual([{
+            filePath,
+            messages: [],
+        }]);
+    });
+
+    test('7.15.0_error.js', async () => {
+        const filePath = '7.15.0_error.js';
+        const data = await lintFile(path.join('fixtures', 'eslint', filePath));
+
+        expect(data).toMatchSnapshot();
+    });
+});

--- a/packages/eslint-config/test/fixtures/eslint/7.15.0_error.js
+++ b/packages/eslint-config/test/fixtures/eslint/7.15.0_error.js
@@ -1,0 +1,3 @@
+/* eslint-disable no-unused-expressions */
+const {obj} = {};
+[...obj?.prop];

--- a/packages/eslint-config/test/fixtures/eslint/7.15.0_ok.js
+++ b/packages/eslint-config/test/fixtures/eslint/7.15.0_ok.js
@@ -1,0 +1,3 @@
+/* eslint-disable no-unused-expressions */
+const {obj} = {};
+obj?.prop;


### PR DESCRIPTION
[ESLint 7.15.0](https://eslint.org/blog/2020/12/eslint-v7.15.0-released) added following rule:

*   [no-unsafe-optional-chaining](https://eslint.org/docs/rules/no-unsafe-optional-chaining)

This PR incorporates new rule to our eslint-config