### PR TITLE
chore: update version of node.js and npm.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,16 +8,16 @@ on:
 
 jobs:
   lint:
-    name: Lint (node.js 14 on ubuntu-latest)
+    name: Lint (node.js 20 on ubuntu-latest)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.1
-      - name: Use node.js 14
+      - name: Use node.js 20
         uses: actions/setup-node@v4.0.0
         with:
-          node-version: 14
-      - name: Install npm@v8
-        run: npm i -g npm@v8
+          node-version: 20
+      - name: Install npm@v10
+        run: npm i -g npm@v10
       - name: Install dependencies
         run: npm ci
       - name: Build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,16 +8,16 @@ on:
 
 jobs:
   test:
-    name: Test (node.js 14 on ubuntu-latest)
+    name: Test (node.js 20 on ubuntu-latest)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.1
-      - name: Use node.js 14
+      - name: Use node.js 20
         uses: actions/setup-node@v4.0.0
         with:
-          node-version: 14
-      - name: Install npm@v8
-        run: npm i -g npm@v8
+          node-version: 20
+      - name: Install npm@v10
+        run: npm i -g npm@v10
       - name: Install dependencies
         run: npm ci
       - name: Build


### PR DESCRIPTION
Update the version of node.js and npm used in GitHub Actions. It means "Linters" will not test with older versions.

* update node.js to v20.x.
* update npm to v10.x.