### PR TITLE
ESLint 8.53.0の対応（コードスタイル関連のルール削除）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@types/eslint": "^8.40.0",
         "cross-env": "^7.0.3",
-        "eslint": "8.52.0",
+        "eslint": "^8.53.0",
         "jest": "^29.7.0",
         "js-green-licenses": "^4.0.0"
       }
@@ -639,9 +639,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.52.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.52.0.tgz",
-      "integrity": "sha512-mjZVbpaeMZludF2fsWLD0Z9gCref1Tk4i9+wddjRvpUNqqcndPkBD09N/Mapey0b3jaXbLm2kICwFv2E64QinA==",
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
+      "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
@@ -2164,15 +2164,15 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.52.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.52.0.tgz",
-      "integrity": "sha512-zh/JHnaixqHZsolRB/w9/02akBk9EPrOs9JwcTP2ek7yL5bVvXuRariiaAjjoJ5DvuwQ1WAE/HsMz+w17YgBCg==",
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
+      "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
-        "@eslint/eslintrc": "^2.1.2",
-        "@eslint/js": "8.52.0",
-        "@humanwhocodes/config-array": "^0.11.13",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.57.0",
+        "@humanwhocodes/config-array": "^0.11.14",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
         "@ungap/structured-clone": "^1.2.0",
@@ -5379,10 +5379,10 @@
     },
     "packages/eslint-config": {
       "name": "@mitsue/eslint-config",
-      "version": "5.0.0",
+      "version": "6.0.0",
       "license": "MIT",
       "peerDependencies": {
-        "eslint": "8.52.0"
+        "eslint": "^8.53.0"
       }
     }
   },
@@ -5851,9 +5851,9 @@
       }
     },
     "@eslint/js": {
-      "version": "8.52.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.52.0.tgz",
-      "integrity": "sha512-mjZVbpaeMZludF2fsWLD0Z9gCref1Tk4i9+wddjRvpUNqqcndPkBD09N/Mapey0b3jaXbLm2kICwFv2E64QinA=="
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
+      "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g=="
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.14",
@@ -7012,15 +7012,15 @@
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
     },
     "eslint": {
-      "version": "8.52.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.52.0.tgz",
-      "integrity": "sha512-zh/JHnaixqHZsolRB/w9/02akBk9EPrOs9JwcTP2ek7yL5bVvXuRariiaAjjoJ5DvuwQ1WAE/HsMz+w17YgBCg==",
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
+      "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
-        "@eslint/eslintrc": "^2.1.2",
-        "@eslint/js": "8.52.0",
-        "@humanwhocodes/config-array": "^0.11.13",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.57.0",
+        "@humanwhocodes/config-array": "^0.11.14",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
         "@ungap/structured-clone": "^1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@types/eslint": "^8.40.0",
         "cross-env": "^7.0.3",
-        "eslint": "8.52.0",
+        "eslint": "^8.53.0",
         "jest": "^29.5.0",
         "js-green-licenses": "^4.0.0"
       }
@@ -656,9 +656,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.52.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.52.0.tgz",
-      "integrity": "sha512-mjZVbpaeMZludF2fsWLD0Z9gCref1Tk4i9+wddjRvpUNqqcndPkBD09N/Mapey0b3jaXbLm2kICwFv2E64QinA==",
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
+      "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
@@ -2133,15 +2133,15 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.52.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.52.0.tgz",
-      "integrity": "sha512-zh/JHnaixqHZsolRB/w9/02akBk9EPrOs9JwcTP2ek7yL5bVvXuRariiaAjjoJ5DvuwQ1WAE/HsMz+w17YgBCg==",
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
+      "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
-        "@eslint/eslintrc": "^2.1.2",
-        "@eslint/js": "8.52.0",
-        "@humanwhocodes/config-array": "^0.11.13",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.57.0",
+        "@humanwhocodes/config-array": "^0.11.14",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
         "@ungap/structured-clone": "^1.2.0",
@@ -5350,10 +5350,10 @@
     },
     "packages/eslint-config": {
       "name": "@mitsue/eslint-config",
-      "version": "4.1.0",
+      "version": "6.0.0",
       "license": "MIT",
       "peerDependencies": {
-        "eslint": ">=8.52.0"
+        "eslint": "^8.53.0"
       }
     }
   },
@@ -5840,9 +5840,9 @@
       }
     },
     "@eslint/js": {
-      "version": "8.52.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.52.0.tgz",
-      "integrity": "sha512-mjZVbpaeMZludF2fsWLD0Z9gCref1Tk4i9+wddjRvpUNqqcndPkBD09N/Mapey0b3jaXbLm2kICwFv2E64QinA=="
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
+      "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g=="
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.14",
@@ -6975,15 +6975,15 @@
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
     },
     "eslint": {
-      "version": "8.52.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.52.0.tgz",
-      "integrity": "sha512-zh/JHnaixqHZsolRB/w9/02akBk9EPrOs9JwcTP2ek7yL5bVvXuRariiaAjjoJ5DvuwQ1WAE/HsMz+w17YgBCg==",
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
+      "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
-        "@eslint/eslintrc": "^2.1.2",
-        "@eslint/js": "8.52.0",
-        "@humanwhocodes/config-array": "^0.11.13",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.57.0",
+        "@humanwhocodes/config-array": "^0.11.14",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
         "@ungap/structured-clone": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "@types/eslint": "^8.40.0",
     "cross-env": "^7.0.3",
-    "eslint": "8.52.0",
+    "eslint": "^8.53.0",
     "jest": "^29.5.0",
     "js-green-licenses": "^4.0.0"
   }

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -76,6 +76,7 @@ npm i --save--dev eslint-config-prettier
 
 |@mitsue/eslint-config|ESLint|
 |-:|-:|
+|6.0.0|>=8.53.0|
 |5.0.0|8.52.0|
 |4.1.0|>=7.30.0|
 |4.0.1|^7.15.0|
@@ -90,6 +91,79 @@ ESLintは未知のルールが設定されているとエラーを報告しま�
 古いバージョンのESLintを利用していないか（このパッケージのpeerDependenciesに指定されているバージョンと合致しているかどうか）ご確認ください。
 
 ## 変更履歴
+
+### 6.0.0
+
+- 対象とするESLint（peerDependencies）を>=8.53.0に変更
+- 非推奨になったスタイルの削除
+    - [array-bracket-newline](https://eslint.org/docs/latest/rules/array-bracket-newline)
+    - [array-bracket-spacing](https://eslint.org/docs/latest/rules/array-bracket-spacing)
+    - [array-element-newline](https://eslint.org/docs/latest/rules/array-element-newline)
+    - [arrow-parens](https://eslint.org/docs/latest/rules/arrow-parens)
+    - [arrow-spacing](https://eslint.org/docs/latest/rules/arrow-spacing)
+    - [block-spacing](https://eslint.org/docs/latest/rules/block-spacing)
+    - [brace-style](https://eslint.org/docs/latest/rules/brace-style)
+    - [comma-dangle](https://eslint.org/docs/latest/rules/comma-dangle)
+    - [comma-spacing](https://eslint.org/docs/latest/rules/comma-spacing)
+    - [comma-style](https://eslint.org/docs/latest/rules/comma-style)
+    - [computed-property-spacing](https://eslint.org/docs/latest/rules/computed-property-spacing)
+    - [dot-location](https://eslint.org/docs/latest/rules/dot-location)
+    - [eol-last](https://eslint.org/docs/latest/rules/eol-last)
+    - [func-call-spacing](https://eslint.org/docs/latest/rules/func-call-spacing)
+    - [function-call-argument-newline](https://eslint.org/docs/latest/rules/function-call-argument-newline)
+    - [function-paren-newline](https://eslint.org/docs/latest/rules/function-paren-newline)
+    - [generator-star-spacing](https://eslint.org/docs/latest/rules/generator-star-spacing)
+    - [implicit-arrow-linebreak](https://eslint.org/docs/latest/rules/implicit-arrow-linebreak)
+    - [indent](https://eslint.org/docs/latest/rules/indent)
+    - [jsx-quotes](https://eslint.org/docs/latest/rules/jsx-quotes)
+    - [key-spacing](https://eslint.org/docs/latest/rules/key-spacing)
+    - [keyword-spacing](https://eslint.org/docs/latest/rules/keyword-spacing)
+    - [linebreak-style](https://eslint.org/docs/latest/rules/linebreak-style)
+    - [lines-between-class-members](https://eslint.org/docs/latest/rules/lines-between-class-members)
+    - [lines-around-comment](https://eslint.org/docs/latest/rules/lines-around-comment)
+    - [max-len](https://eslint.org/docs/latest/rules/max-len)
+    - [max-statements-per-line](https://eslint.org/docs/latest/rules/max-statements-per-line)
+    - [multiline-ternary](https://eslint.org/docs/latest/rules/multiline-ternary)
+    - [new-parens](https://eslint.org/docs/latest/rules/new-parens)
+    - [newline-per-chained-call](https://eslint.org/docs/latest/rules/newline-per-chained-call)
+    - [no-confusing-arrow](https://eslint.org/docs/latest/rules/no-confusing-arrow)
+    - [no-extra-parens](https://eslint.org/docs/latest/rules/no-extra-parens)
+    - [no-extra-semi](https://eslint.org/docs/latest/rules/no-extra-semi)
+    - [no-floating-decimal](https://eslint.org/docs/latest/rules/no-floating-decimal)
+    - [no-mixed-operators](https://eslint.org/docs/latest/rules/no-mixed-operators)
+    - [no-mixed-spaces-and-tabs](https://eslint.org/docs/latest/rules/no-mixed-spaces-and-tabs)
+    - [no-multi-spaces](https://eslint.org/docs/latest/rules/no-multi-spaces)
+    - [no-multiple-empty-lines](https://eslint.org/docs/latest/rules/no-multiple-empty-lines)
+    - [no-tabs](https://eslint.org/docs/latest/rules/no-tabs)
+    - [no-trailing-spaces](https://eslint.org/docs/latest/rules/no-trailing-spaces)
+    - [no-whitespace-before-property](https://eslint.org/docs/latest/rules/no-whitespace-before-property)
+    - [nonblock-statement-body-position](https://eslint.org/docs/latest/rules/nonblock-statement-body-position)
+    - [object-curly-newline](https://eslint.org/docs/latest/rules/object-curly-newline)
+    - [object-curly-spacing](https://eslint.org/docs/latest/rules/object-curly-spacing)
+    - [object-property-newline](https://eslint.org/docs/latest/rules/object-property-newline)
+    - [one-var-declaration-per-line](https://eslint.org/docs/latest/rules/one-var-declaration-per-line)
+    - [operator-linebreak](https://eslint.org/docs/latest/rules/operator-linebreak)
+    - [padded-blocks](https://eslint.org/docs/latest/rules/padded-blocks)
+    - [padding-line-between-statements](https://eslint.org/docs/latest/rules/padding-line-between-statements)
+    - [quote-props](https://eslint.org/docs/latest/rules/quote-props)
+    - [quotes](https://eslint.org/docs/latest/rules/quotes)
+    - [rest-spread-spacing](https://eslint.org/docs/latest/rules/rest-spread-spacing)
+    - [semi](https://eslint.org/docs/latest/rules/semi)
+    - [semi-spacing](https://eslint.org/docs/latest/rules/semi-spacing)
+    - [semi-style](https://eslint.org/docs/latest/rules/semi-style)
+    - [space-before-blocks](https://eslint.org/docs/latest/rules/space-before-blocks)
+    - [space-before-function-paren](https://eslint.org/docs/latest/rules/space-before-function-paren)
+    - [space-in-parens](https://eslint.org/docs/latest/rules/space-in-parens)
+    - [space-infix-ops](https://eslint.org/docs/latest/rules/space-infix-ops)
+    - [space-unary-ops](https://eslint.org/docs/latest/rules/space-unary-ops)
+    - [spaced-comment](https://eslint.org/docs/latest/rules/spaced-comment)
+    - [switch-colon-spacing](https://eslint.org/docs/latest/rules/switch-colon-spacing)
+    - [template-curly-spacing](https://eslint.org/docs/latest/rules/template-curly-spacing)
+    - [template-tag-spacing](https://eslint.org/docs/latest/rules/template-tag-spacing)
+    - [wrap-iife](https://eslint.org/docs/latest/rules/wrap-iife)
+    - [wrap-regex](https://eslint.org/docs/latest/rules/wrap-regex)
+    - [yield-star-spacing](https://eslint.org/docs/latest/rules/yield-star-spacing)
+
 
 ### 5.0.0
 

--- a/packages/eslint-config/index.cjs
+++ b/packages/eslint-config/index.cjs
@@ -377,9 +377,6 @@ module.exports = {
         // https://eslint.org/docs/rules/no-case-declarations
         'no-case-declarations': 2,
 
-        // TODO: 削除 https://eslint.org/docs/rules/no-confusing-arrow
-        'no-confusing-arrow': 2,
-
         // https://eslint.org/docs/rules/no-console
         'no-console': 1,
 
@@ -421,12 +418,6 @@ module.exports = {
 
         // https://eslint.org/docs/rules/no-extra-label
         'no-extra-label': 2,
-
-        // TODO: 削除 https://eslint.org/docs/rules/no-extra-semi
-        'no-extra-semi': 2,
-
-        // TODO: 削除 https://eslint.org/docs/rules/no-floating-decimal
-        'no-floating-decimal': 2,
 
         // https://eslint.org/docs/rules/no-global-assign
         'no-global-assign': 2,
@@ -471,9 +462,6 @@ module.exports = {
 
         // https://eslint.org/docs/rules/no-magic-numbers
         'no-magic-numbers': 0,
-
-        // TODO: 削除 https://eslint.org/docs/rules/no-mixed-operators
-        'no-mixed-operators': 2,
 
         // https://eslint.org/docs/rules/no-multi-assign
         'no-multi-assign': 2,
@@ -678,9 +666,6 @@ module.exports = {
             },
         ],
 
-        // TODO: 削除 https://eslint.org/docs/rules/one-var-declaration-per-line
-        'one-var-declaration-per-line': 0,
-
         // https://eslint.org/docs/rules/operator-assignment
         'operator-assignment': [
             2,
@@ -749,12 +734,6 @@ module.exports = {
         // https://eslint.org/docs/rules/prefer-template
         'prefer-template': 2,
 
-        // TODO: 削除 https://eslint.org/docs/rules/quote-props
-        'quote-props': [
-            2,
-            'as-needed',
-        ],
-
         // https://eslint.org/docs/rules/radix
         radix: 0,
 
@@ -776,22 +755,6 @@ module.exports = {
         // https://eslint.org/docs/rules/sort-vars
         'sort-vars': 0,
 
-        // TODO: 削除 https://eslint.org/docs/rules/spaced-comment
-        'spaced-comment': [
-            2,
-            'always',
-            {
-                block: {
-                    markers: [
-                        '*',
-                        '!',
-                        '*!',
-                    ],
-                    balanced: true,
-                },
-            },
-        ],
-
         // https://eslint.org/docs/rules/strict
         strict: [
             2,
@@ -811,421 +774,13 @@ module.exports = {
          * Layout & Formatting
          */
 
-        // TODO: 削除 https://eslint.org/docs/rules/array-bracket-newline
-        'array-bracket-newline': 0,
-
-        // TODO: 削除 https://eslint.org/docs/rules/array-bracket-spacing
-        'array-bracket-spacing': [
-            2,
-            'never',
-        ],
-
-        // TODO: 削除 https://eslint.org/docs/rules/array-element-newline
-        'array-element-newline': 0,
-
-        // TODO: 削除 https://eslint.org/docs/rules/arrow-parens
-        'arrow-parens': [
-            2,
-            'always',
-        ],
-
-        // TODO: 削除 https://eslint.org/docs/rules/arrow-spacing
-        'arrow-spacing': 2,
-
-        // TODO: 削除 https://eslint.org/docs/rules/block-spacing
-        'block-spacing': [
-            2,
-            'always',
-        ],
-
-        // TODO: 削除 https://eslint.org/docs/rules/brace-style
-        'brace-style': [
-            2,
-            '1tbs',
-            {
-                allowSingleLine: false,
-            },
-        ],
-
-        // TODO: 削除 https://eslint.org/docs/rules/comma-dangle
-        'comma-dangle': [
-            2,
-            'always-multiline',
-        ],
-
-        // TODO: 削除 https://eslint.org/docs/rules/comma-spacing
-        'comma-spacing': [
-            2,
-            {
-                before: false,
-                after: true,
-            },
-        ],
-
-        // TODO: 削除 https://eslint.org/docs/rules/comma-style
-        'comma-style': [
-            2,
-            'last',
-        ],
-
-        // TODO: 削除 https://eslint.org/docs/rules/computed-property-spacing
-        'computed-property-spacing': [
-            2,
-            'never',
-            {
-                enforceForClassMembers: true,
-            },
-        ],
-
-        // TODO: 削除 https://eslint.org/docs/rules/dot-location
-        'dot-location': [
-            2,
-            'object',
-        ],
-
-        // TODO: 削除 https://eslint.org/docs/rules/eol-last
-        'eol-last': 2,
-
-        // TODO: 削除 https://eslint.org/docs/rules/func-call-spacing
-        'func-call-spacing': [
-            2,
-            'never',
-        ],
-
-        // TODO: 削除 https://eslint.org/docs/rules/function-call-argument-newline
-        'function-call-argument-newline': [
-            2,
-            'consistent',
-        ],
-
-        // TODO: 削除 https://eslint.org/docs/rules/function-paren-newline
-        'function-paren-newline': [
-            2,
-            'multiline',
-        ],
-
-        // TODO: 削除 https://eslint.org/docs/rules/generator-star-spacing
-        'generator-star-spacing': [
-            2,
-            {
-                before: true,
-                after: false,
-                named: {
-                    before: true,
-                    after: false,
-                },
-                anonymous: {
-                    before: true,
-                    after: false,
-                },
-                method: {
-                    before: true,
-                    after: false,
-                },
-            },
-        ],
-
-        // TODO: 削除 https://eslint.org/docs/rules/implicit-arrow-linebreak
-        'implicit-arrow-linebreak': [
-            2,
-            'beside',
-        ],
-
-        // TODO: 削除 https://eslint.org/docs/rules/indent
-        indent: [
-            2,
-            4,
-            {
-                SwitchCase: 0,
-                VariableDeclarator: {
-                    var: 1,
-                    let: 1,
-                    const: 2,
-                },
-                outerIIFEBody: 1,
-                FunctionDeclaration: {
-                    parameters: 'first',
-                    body: 1,
-                },
-                FunctionExpression: {
-                    parameters: 'first',
-                    body: 1,
-                },
-                CallExpression: {
-                    arguments: 'first',
-                },
-                ArrayExpression: 'first',
-                ObjectExpression: 'first',
-                ImportDeclaration: 'first',
-                flatTernaryExpressions: true,
-                ignoreComments: false,
-            },
-        ],
-
-        // TODO: 削除 https://eslint.org/docs/rules/jsx-quotes
-        'jsx-quotes': [
-            2,
-            'prefer-double',
-        ],
-
-        // TODO: 削除 https://eslint.org/docs/rules/key-spacing
-        'key-spacing': 2,
-
-        // TODO: 削除 https://eslint.org/docs/rules/keyword-spacing
-        'keyword-spacing': 2,
-
         // TODO: 削除 https://eslint.org/docs/rules/line-comment-position
         'line-comment-position': 0,
-
-        // TODO: 削除 https://eslint.org/docs/rules/linebreak-style
-        'linebreak-style': [
-            2,
-            'unix',
-        ],
-
-        // TODO: 削除 https://eslint.org/docs/rules/lines-around-comment
-        'lines-around-comment': 0,
-
-        // TODO: 削除 https://eslint.org/docs/rules/lines-between-class-members
-        'lines-between-class-members': [
-            2,
-            'always',
-            {
-                exceptAfterSingleLine: false,
-            },
-        ],
-
-        // TODO: 削除 https://eslint.org/docs/rules/max-len
-        'max-len': 0,
-
-        // TODO: 削除 https://eslint.org/docs/rules/max-statements-per-line
-        'max-statements-per-line': 0,
-
-        // TODO: 削除 https://eslint.org/docs/rules/multiline-ternary
-        'multiline-ternary': 0,
-
-        // TODO: 削除 https://eslint.org/docs/rules/new-parens
-        'new-parens': 2,
-
-        // TODO: 削除 https://eslint.org/docs/rules/newline-per-chained-call
-        'newline-per-chained-call': 0,
-
-        // TODO: 削除 https://eslint.org/docs/rules/no-extra-parens
-        'no-extra-parens': [
-            2,
-            'functions',
-        ],
-
-        // TODO: 削除 https://eslint.org/docs/rules/no-mixed-spaces-and-tabs
-        'no-mixed-spaces-and-tabs': 2,
-
-        // TODO: 削除 https://eslint.org/docs/rules/no-multi-spaces
-        'no-multi-spaces': 2,
-
-        // TODO: 削除 https://eslint.org/docs/rules/no-multiple-empty-lines
-        'no-multiple-empty-lines': [
-            2,
-            {
-                max: 3,
-            },
-        ],
-
-        // TODO: 削除 https://eslint.org/docs/rules/no-tabs
-        'no-tabs': 1,
-
-        // TODO: 削除 https://eslint.org/docs/rules/no-trailing-spaces
-        'no-trailing-spaces': [
-            2,
-            {
-                skipBlankLines: false,
-                ignoreComments: false,
-            },
-        ],
-
-        // TODO: 削除 https://eslint.org/docs/rules/no-whitespace-before-property
-        'no-whitespace-before-property': 2,
-
-        // TODO: 削除 https://eslint.org/docs/rules/nonblock-statement-body-position
-        'nonblock-statement-body-position': [
-            2,
-            'beside',
-        ],
-
-        // TODO: 削除 https://eslint.org/docs/rules/object-curly-newline
-        'object-curly-newline': 0,
-
-        // TODO: 削除 https://eslint.org/docs/rules/object-curly-spacing
-        'object-curly-spacing': [
-            2,
-            'never',
-        ],
-
-        // TODO: 削除 https://eslint.org/docs/rules/object-property-newline
-        'object-property-newline': 2,
-
-        // TODO: 削除 https://eslint.org/docs/rules/operator-linebreak
-        'operator-linebreak': 0,
-
-        // TODO: 削除 https://eslint.org/docs/rules/padded-blocks
-        'padded-blocks': [
-            2,
-            'never',
-        ],
-
-        // TODO: 削除 https://eslint.org/docs/rules/padding-line-between-statements
-        'padding-line-between-statements': [
-            2,
-            {
-                blankLine: 'always',
-                prev: '*',
-                next: 'return',
-            },
-            {
-                blankLine: 'always',
-                prev: [
-                    'var',
-                ],
-                next: '*',
-            },
-            {
-                blankLine: 'any',
-                prev: [
-                    'var',
-                ],
-                next: [
-                    'const',
-                    'let',
-                    'var',
-                ],
-            },
-            {
-                blankLine: 'always',
-                prev: 'directive',
-                next: '*',
-            },
-            {
-                blankLine: 'any',
-                prev: 'directive',
-                next: 'directive',
-            },
-        ],
-
-        // TODO: 削除 https://eslint.org/docs/rules/quotes
-        quotes: [
-            2,
-            'single',
-            'avoid-escape',
-        ],
-
-        // TODO: 削除 https://eslint.org/docs/rules/rest-spread-spacing
-        'rest-spread-spacing': [
-            2,
-            'never',
-        ],
-
-        // TODO: 削除 https://eslint.org/docs/rules/semi
-        semi: [
-            2,
-            'always',
-        ],
-
-        // TODO: 削除 https://eslint.org/docs/rules/semi-spacing
-        'semi-spacing': [
-            2,
-            {
-                before: false,
-                after: true,
-            },
-        ],
-
-        // TODO: 削除 https://eslint.org/docs/rules/semi-style
-        'semi-style': [
-            2,
-            'last',
-        ],
-
-        // TODO: 削除 https://eslint.org/docs/rules/space-before-blocks
-        'space-before-blocks': [
-            2,
-            'always',
-        ],
-
-        // TODO: 削除 https://eslint.org/docs/rules/space-before-function-paren
-        'space-before-function-paren': [
-            2,
-            {
-                anonymous: 'always',
-                named: 'never',
-                asyncArrow: 'always',
-            },
-        ],
-
-        // TODO: 削除 https://eslint.org/docs/rules/space-in-parens
-        'space-in-parens': [
-            2,
-            'never',
-        ],
-
-        // TODO: 削除 https://eslint.org/docs/rules/space-infix-ops
-        'space-infix-ops': [
-            2,
-            {
-                int32Hint: true,
-            },
-        ],
-
-        // TODO: 削除 https://eslint.org/docs/rules/space-unary-ops
-        'space-unary-ops': [
-            2,
-            {
-                words: true,
-                nonwords: false,
-            },
-        ],
-
-        // TODO: 削除 https://eslint.org/docs/rules/switch-colon-spacing
-        'switch-colon-spacing': [
-            2,
-            {
-                after: false,
-                before: false,
-            },
-        ],
-
-        // TODO: 削除 https://eslint.org/docs/rules/template-curly-spacing
-        'template-curly-spacing': [
-            2,
-            'never',
-        ],
-
-        // TODO: 削除 https://eslint.org/docs/rules/template-tag-spacing
-        'template-tag-spacing': [
-            2,
-            'never',
-        ],
 
         // https://eslint.org/docs/rules/unicode-bom
         'unicode-bom': [
             1,
             'never',
-        ],
-
-        // TODO: 削除 https://eslint.org/docs/rules/wrap-iife
-        'wrap-iife': [
-            2,
-            'outside',
-        ],
-
-        // TODO: 削除 https://eslint.org/docs/rules/wrap-regex
-        'wrap-regex': 0,
-
-        // TODO: 削除 https://eslint.org/docs/rules/yield-star-spacing
-        'yield-star-spacing': [
-            2,
-            {
-                before: false,
-                after: true,
-            },
         ],
     },
 

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mitsue/eslint-config",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "eslint config for Mitsue-Links",
   "main": "index.cjs",
   "files": [
@@ -27,6 +27,6 @@
     "directory": "packages/eslint-config"
   },
   "peerDependencies": {
-    "eslint": "8.52.0"
+    "eslint": "^8.53.0"
   }
 }

--- a/packages/eslint-config/test/__snapshots__/comma-dangle.test.mjs.snap
+++ b/packages/eslint-config/test/__snapshots__/comma-dangle.test.mjs.snap
@@ -4,23 +4,7 @@ exports[`comma-dangle_error.mjs 1`] = `
 [
   {
     "filePath": "comma-dangle_error.mjs",
-    "messages": [
-      {
-        "line": 12,
-        "ruleId": "comma-dangle",
-        "severity": 2,
-      },
-      {
-        "line": 18,
-        "ruleId": "comma-dangle",
-        "severity": 2,
-      },
-      {
-        "line": 30,
-        "ruleId": "comma-dangle",
-        "severity": 2,
-      },
-    ],
+    "messages": [],
   },
 ]
 `;

--- a/packages/eslint-config/test/__snapshots__/eslint6.test.mjs.snap
+++ b/packages/eslint-config/test/__snapshots__/eslint6.test.mjs.snap
@@ -6,24 +6,19 @@ exports[`ESLint 6.2.0 6.2.0_error.mjs 1`] = `
     "filePath": "6.2.0_error.mjs",
     "messages": [
       {
-        "line": 4,
-        "ruleId": "function-call-argument-newline",
-        "severity": 2,
+        "line": 2,
+        "ruleId": "Unused eslint-disable directive (no problems were reported from 'function-paren-newline').",
+        "severity": 1,
       },
       {
-        "line": 8,
-        "ruleId": "function-call-argument-newline",
-        "severity": 2,
+        "line": 2,
+        "ruleId": "Unused eslint-disable directive (no problems were reported from 'object-curly-spacing').",
+        "severity": 1,
       },
       {
-        "line": 10,
-        "ruleId": "function-call-argument-newline",
-        "severity": 2,
-      },
-      {
-        "line": 14,
-        "ruleId": "function-call-argument-newline",
-        "severity": 2,
+        "line": 2,
+        "ruleId": "Unused eslint-disable directive (no problems were reported from 'object-property-newline').",
+        "severity": 1,
       },
     ],
   },
@@ -43,21 +38,6 @@ exports[`ESLint 6.4.0 6.4.0_error.mjs 1`] = `
       {
         "line": 10,
         "ruleId": "default-param-last",
-        "severity": 2,
-      },
-      {
-        "line": 21,
-        "ruleId": "computed-property-spacing",
-        "severity": 2,
-      },
-      {
-        "line": 25,
-        "ruleId": "computed-property-spacing",
-        "severity": 2,
-      },
-      {
-        "line": 29,
-        "ruleId": "computed-property-spacing",
         "severity": 2,
       },
     ],

--- a/packages/eslint-config/test/__snapshots__/fsg.test.mjs.snap
+++ b/packages/eslint-config/test/__snapshots__/fsg.test.mjs.snap
@@ -21,21 +21,6 @@ exports[`fsg_error.mjs 1`] = `
         "severity": 2,
       },
       {
-        "line": 11,
-        "ruleId": "indent",
-        "severity": 2,
-      },
-      {
-        "line": 12,
-        "ruleId": "indent",
-        "severity": 2,
-      },
-      {
-        "line": 13,
-        "ruleId": "indent",
-        "severity": 2,
-      },
-      {
         "line": 13,
         "ruleId": "no-undef",
         "severity": 2,
@@ -52,27 +37,12 @@ exports[`fsg_error.mjs 1`] = `
       },
       {
         "line": 14,
-        "ruleId": "indent",
-        "severity": 2,
-      },
-      {
-        "line": 14,
         "ruleId": "no-undef",
         "severity": 2,
       },
       {
         "line": 14,
         "ruleId": "no-undef",
-        "severity": 2,
-      },
-      {
-        "line": 21,
-        "ruleId": "brace-style",
-        "severity": 2,
-      },
-      {
-        "line": 21,
-        "ruleId": "brace-style",
         "severity": 2,
       },
       {
@@ -151,148 +121,13 @@ exports[`fsg_error.mjs 1`] = `
         "severity": 2,
       },
       {
-        "line": 101,
-        "ruleId": "indent",
-        "severity": 2,
-      },
-      {
-        "line": 101,
-        "ruleId": "no-tabs",
-        "severity": 1,
-      },
-      {
-        "line": 102,
-        "ruleId": "no-mixed-spaces-and-tabs",
-        "severity": 2,
-      },
-      {
-        "line": 102,
-        "ruleId": "no-tabs",
-        "severity": 1,
-      },
-      {
-        "line": 103,
-        "ruleId": "no-mixed-spaces-and-tabs",
-        "severity": 2,
-      },
-      {
-        "line": 103,
-        "ruleId": "no-tabs",
-        "severity": 1,
-      },
-      {
-        "line": 104,
-        "ruleId": "no-mixed-spaces-and-tabs",
-        "severity": 2,
-      },
-      {
-        "line": 104,
-        "ruleId": "no-tabs",
-        "severity": 1,
-      },
-      {
-        "line": 105,
-        "ruleId": "indent",
-        "severity": 2,
-      },
-      {
-        "line": 105,
-        "ruleId": "no-tabs",
-        "severity": 1,
-      },
-      {
-        "line": 107,
-        "ruleId": "indent",
-        "severity": 2,
-      },
-      {
-        "line": 107,
-        "ruleId": "no-tabs",
-        "severity": 1,
-      },
-      {
         "line": 114,
         "ruleId": "one-var",
         "severity": 2,
       },
       {
-        "line": 114,
-        "ruleId": "comma-spacing",
-        "severity": 2,
-      },
-      {
-        "line": 114,
-        "ruleId": "comma-spacing",
-        "severity": 2,
-      },
-      {
-        "line": 117,
-        "ruleId": "key-spacing",
-        "severity": 2,
-      },
-      {
-        "line": 118,
-        "ruleId": "key-spacing",
-        "severity": 2,
-      },
-      {
-        "line": 124,
-        "ruleId": "key-spacing",
-        "severity": 2,
-      },
-      {
-        "line": 125,
-        "ruleId": "key-spacing",
-        "severity": 2,
-      },
-      {
-        "line": 129,
-        "ruleId": "switch-colon-spacing",
-        "severity": 2,
-      },
-      {
-        "line": 132,
-        "ruleId": "switch-colon-spacing",
-        "severity": 2,
-      },
-      {
-        "line": 135,
-        "ruleId": "switch-colon-spacing",
-        "severity": 2,
-      },
-      {
-        "line": 139,
-        "ruleId": "space-infix-ops",
-        "severity": 2,
-      },
-      {
-        "line": 139,
-        "ruleId": "space-infix-ops",
-        "severity": 2,
-      },
-      {
-        "line": 139,
-        "ruleId": "space-infix-ops",
-        "severity": 2,
-      },
-      {
         "line": 142,
         "ruleId": "curly",
-        "severity": 2,
-      },
-      {
-        "line": 142,
-        "ruleId": "nonblock-statement-body-position",
-        "severity": 2,
-      },
-      {
-        "line": 144,
-        "ruleId": "space-unary-ops",
-        "severity": 2,
-      },
-      {
-        "line": 146,
-        "ruleId": "space-unary-ops",
         "severity": 2,
       },
     ],

--- a/packages/eslint-config/test/__snapshots__/padding-lines.test.mjs.snap
+++ b/packages/eslint-config/test/__snapshots__/padding-lines.test.mjs.snap
@@ -11,18 +11,8 @@ exports[`padding-lines_error.mjs 1`] = `
         "severity": 2,
       },
       {
-        "line": 14,
-        "ruleId": "padding-line-between-statements",
-        "severity": 2,
-      },
-      {
         "line": 17,
         "ruleId": "vars-on-top",
-        "severity": 2,
-      },
-      {
-        "line": 18,
-        "ruleId": "padding-line-between-statements",
         "severity": 2,
       },
     ],

--- a/packages/eslint-config/test/fixtures/eslint/6.2.0_ok.mjs
+++ b/packages/eslint-config/test/fixtures/eslint/6.2.0_ok.mjs
@@ -1,5 +1,5 @@
 // function-call-argument-newline
-/* eslint-disable no-unused-vars, no-undef, object-property-newline, object-curly-spacing */
+/* eslint-disable no-unused-vars, no-undef */
 (function () {
     foo('one', 'two', 'three');
     // or
@@ -41,4 +41,4 @@
         },
     );
 }());
-/* eslint-enable no-unused-vars, no-undef, object-property-newline, object-curly-spacing */
+/* eslint-enable no-unused-vars, no-undef */


### PR DESCRIPTION
非推奨となったコードスタイル関連のルールを削除します。

* [ESLint v8.53.0](https://eslint.org/blog/2023/11/eslint-v8.53.0-released/)
* [ESLint v8.54.0](https://eslint.org/blog/2023/11/eslint-v8.54.0-released/)
* [ESLint v8.55.0](https://eslint.org/blog/2023/12/eslint-v8.55.0-released/)
* [ESLint v8.56.0](https://eslint.org/blog/2023/12/eslint-v8.56.0-released/)
* [ESLint v8.57.0](https://eslint.org/blog/2024/02/eslint-v8.57.0-released/)

FlatConfigへは次のリリースで移行します。